### PR TITLE
raise when given a bad cronline

### DIFF
--- a/lib/cron_parser.rb
+++ b/lib/cron_parser.rb
@@ -53,6 +53,7 @@ class CronParser
   def initialize(source,time_source = Time)
     @source = source
     @time_source = time_source
+    validate_source
   end
 
 
@@ -235,6 +236,16 @@ class CronParser
       allowed.sort.find { |val| val > current }
     else
       allowed.sort.reverse.find { |val| val < current }
+    end
+  end
+
+  def validate_source
+    unless @source.respond_to?(:split)
+      raise ArgumentError, 'not a valid cronline'
+    end
+    source_length = @source.split(/\s+/).length
+    unless source_length >= 5 && source_length <= 6
+      raise ArgumentError, 'not a valid cronline'
     end
   end
 end

--- a/spec/cron_parser_spec.rb
+++ b/spec/cron_parser_spec.rb
@@ -18,7 +18,7 @@ describe "CronParser#parse_element" do
     ["10-40/10", 0..60, [10, 20, 30, 40]],
   ].each do |element, range, expected|
     it "should return #{expected} for '#{element}' when range is #{range}" do
-      parser = CronParser.new('')
+      parser = CronParser.new('* * * * *')
       parser.parse_element(element, range) == expected
     end
   end
@@ -79,6 +79,16 @@ describe "CronParser#last" do
 
       parser.last(now).should == expected_next
     end
+  end
+end
+
+describe "CronParser#new" do
+  it 'should not raise error when given a valid cronline' do
+    expect { CronParser.new('30 * * * *') }.not_to raise_error
+  end
+
+  it 'should raise error when given an invalid cronline' do
+    expect { CronParser.new('* * * *') }.to raise_error('not a valid cronline')
   end
 end
 


### PR DESCRIPTION
Hey there. Given an invalid cronline as input the CronParser will now raise an argument error. More really could be done to validate the cronline input, but it would require some changes or something hacky like calling #next in the initializer to check for correctness. Let me know what you think.

Thanks,
B!
