### PR TITLE
Fix for error thrown when using int/int format cron

### DIFF
--- a/lib/cron_parser.rb
+++ b/lib/cron_parser.rb
@@ -136,7 +136,7 @@ class CronParser
   end
 
 
-  SUBELEMENT_REGEX = %r{^(\d+)(-(\d+)(/(\d+))?)?$}
+  SUBELEMENT_REGEX = %r{^(\d+)((-(\d+))?(/(\d+))?)?$}
   def parse_element(elem, allowed_range)
     values = elem.split(',').map do |subel|
       if subel =~ /^\*/
@@ -144,10 +144,12 @@ class CronParser
         stepped_range(allowed_range, step)
       else
         if SUBELEMENT_REGEX === subel
-          if $5 # with range
-            stepped_range($1.to_i..$3.to_i, $5.to_i)
-          elsif $3 # range without step
-            stepped_range($1.to_i..$3.to_i, 1)
+          if $6 && $4 # range with step
+            stepped_range($1.to_i..$4.to_i, $6.to_i)
+          elsif $6 && !$4 # step without range
+            stepped_range($1.to_i..allowed_range.end, $6.to_i)
+          elsif $4 # range without step
+            stepped_range($1.to_i..$4.to_i, 1)
           else # just a numeric
             [$1.to_i]
           end

--- a/spec/cron_parser_spec.rb
+++ b/spec/cron_parser_spec.rb
@@ -157,6 +157,7 @@ describe "CronParser#last" do
     ["15-59/15 * * * *",      "2014-02-01 15:36",  "2014-02-01 15:30"],
     ["15-59/15 * * * *",      "2014-02-01 15:45",  "2014-02-01 15:30"],
     ["15-59/15 * * * *",      "2014-02-01 15:46",  "2014-02-01 15:45"],
+    ["15/15 * * * *",         "2014-02-01 15:46",  "2014-02-01 15:45"]
   ].each do |line, now, expected_next|
     it "should return #{expected_next} for '#{line}' when now is #{now}" do
       now = parse_date(now)


### PR DESCRIPTION
Previously parse_element worked with both */int and int-int/int step formats, but would throw an error when doing int/int (e.g. 1/5).

I've added a spec that covers this and a fix for it.
